### PR TITLE
fix(documents): recover from create cleanup failures

### DIFF
--- a/src/documents/service.py
+++ b/src/documents/service.py
@@ -201,6 +201,34 @@ class DocumentService:
                 retries=3,
             )
             if cleanup_failed_keys:
+                recovered_document = self._persist_document_after_incomplete_create_cleanup(
+                    document_id=document_id,
+                    owner_user_id=owner_user_id,
+                    filename=filename,
+                    content_type=content_type,
+                    file_data=file_data,
+                    markdown_content=markdown_content,
+                    canonical_json_content=canonical_json_content,
+                    source_object_key=source_object_key,
+                    markdown_object_key=markdown_object_key,
+                    canonical_json_object_key=canonical_json_object_key,
+                    remaining_object_keys=cleanup_failed_keys,
+                )
+                if recovered_document is not None:
+                    logger.warning(
+                        (
+                            "create cleanup was incomplete, persisted fallback "
+                            "document for document_id=%s keys=%s"
+                        ),
+                        document_id,
+                        ",".join(cleanup_failed_keys),
+                    )
+                    return self._to_document_parse_response(
+                        recovered_document,
+                        markdown=markdown_content,
+                        canonical_json=canonical_json_content,
+                    )
+
                 logger.error(
                     "create cleanup failed for document_id=%s keys=%s",
                     document_id,
@@ -314,20 +342,8 @@ class DocumentService:
         if document.result is None:
             raise DocumentNotFoundError(UUID(document.id))
 
-        markdown_object_key = document.result.markdown_object_key
-        canonical_json_object_key = document.result.canonical_json_object_key
-        if markdown_object_key and canonical_json_object_key:
-            markdown = self.storage.get_bytes(key=markdown_object_key).decode("utf-8")
-            canonical_json_raw = self.storage.get_bytes(
-                key=canonical_json_object_key,
-            ).decode("utf-8")
-            canonical_json = json.loads(canonical_json_raw)
-            if not isinstance(canonical_json, dict):
-                raise ValueError("canonical json payload must be a JSON object")
-            return markdown, canonical_json
-
-        markdown = document.result.markdown
-        canonical_json = document.result.canonical_json
+        markdown = self._load_markdown_payload(document.result)
+        canonical_json = self._load_canonical_json_payload(document.result)
         if markdown is None or canonical_json is None:
             raise DocumentNotFoundError(UUID(document.id))
         return markdown, canonical_json
@@ -362,6 +378,59 @@ class DocumentService:
             if not deleted:
                 failed.append(key)
         return failed
+
+    def _persist_document_after_incomplete_create_cleanup(
+        self,
+        *,
+        document_id: str,
+        owner_user_id: str,
+        filename: str,
+        content_type: str,
+        file_data: bytes,
+        markdown_content: str,
+        canonical_json_content: dict[str, Any],
+        source_object_key: str,
+        markdown_object_key: str,
+        canonical_json_object_key: str,
+        remaining_object_keys: list[str],
+    ) -> DocumentModel | None:
+        remaining_keys = set(remaining_object_keys)
+        document = DocumentModel(
+            id=document_id,
+            owner_user_id=owner_user_id,
+            source_object_key=source_object_key if source_object_key in remaining_keys else None,
+            filename=filename,
+            content_type=content_type,
+            file_data=file_data,
+        )
+        document.result = DocumentResultModel(
+            document_id=document_id,
+            markdown=markdown_content,
+            canonical_json=canonical_json_content,
+            markdown_object_key=markdown_object_key
+            if markdown_object_key in remaining_keys
+            else None,
+            canonical_json_object_key=(
+                canonical_json_object_key if canonical_json_object_key in remaining_keys else None
+            ),
+        )
+        self.session.add(document)
+        try:
+            self.session.commit()
+        except Exception as exc:
+            self.session.rollback()
+            logger.error(
+                (
+                    "failed to persist fallback document after incomplete "
+                    "create cleanup for document_id=%s"
+                ),
+                document_id,
+                exc_info=exc,
+            )
+            return None
+        self.session.refresh(document)
+        self.session.refresh(document, attribute_names=["result"])
+        return document
 
     def _delete_objects_strict(self, keys: list[str]) -> tuple[dict[str, bytes], list[str]]:
         backup_payloads: dict[str, bytes] = {}
@@ -423,6 +492,40 @@ class DocumentService:
                 )
                 failed.append(key)
         return failed
+
+    def _load_markdown_payload(self, result: DocumentResultModel) -> str | None:
+        if result.markdown_object_key:
+            try:
+                return self.storage.get_bytes(key=result.markdown_object_key).decode("utf-8")
+            except Exception as exc:
+                if result.markdown is None:
+                    raise
+                logger.warning(
+                    "failed to read markdown object key=%s, using inline fallback",
+                    result.markdown_object_key,
+                    exc_info=exc,
+                )
+        return result.markdown
+
+    def _load_canonical_json_payload(self, result: DocumentResultModel) -> dict[str, Any] | None:
+        if result.canonical_json_object_key:
+            try:
+                canonical_json_raw = self.storage.get_bytes(
+                    key=result.canonical_json_object_key,
+                ).decode("utf-8")
+                canonical_json = json.loads(canonical_json_raw)
+                if not isinstance(canonical_json, dict):
+                    raise ValueError("canonical json payload must be a JSON object")
+                return canonical_json
+            except Exception as exc:
+                if result.canonical_json is None:
+                    raise
+                logger.warning(
+                    "failed to read canonical json object key=%s, using inline fallback",
+                    result.canonical_json_object_key,
+                    exc_info=exc,
+                )
+        return result.canonical_json
 
     @staticmethod
     def _content_type_for_key(key: str) -> str:

--- a/tests/documents/test_service.py
+++ b/tests/documents/test_service.py
@@ -175,7 +175,9 @@ def test_create_document_rolls_back_storage_on_write_failure(db_session) -> None
     assert storage.objects == {}
 
 
-def test_create_document_raises_when_cleanup_after_failure_is_incomplete(db_session) -> None:
+def test_create_document_persists_fallback_when_cleanup_after_failure_is_incomplete(
+    db_session,
+) -> None:
     class CreateCleanupFailingStorage:
         def __init__(self) -> None:
             self.objects: dict[str, bytes] = {}
@@ -203,16 +205,130 @@ def test_create_document_raises_when_cleanup_after_failure_is_incomplete(db_sess
     service = DocumentService(session=db_session, storage=storage)
     owner_user_id = _create_user(db_session)
 
-    with pytest.raises(RuntimeError, match="object cleanup is incomplete"):
-        service.create_document(
-            owner_user_id=owner_user_id,
-            filename="cleanup-fail.pdf",
-            content_type="application/pdf",
-            file_data=b"cleanup-fail",
-        )
+    created = service.create_document(
+        owner_user_id=owner_user_id,
+        filename="cleanup-fail.pdf",
+        content_type="application/pdf",
+        file_data=b"cleanup-fail",
+    )
 
-    # Document row must not exist even when cleanup is incomplete.
-    assert db_session.query(DocumentModel).count() == 0
+    assert created.document.filename == "cleanup-fail.pdf"
+    assert db_session.query(DocumentModel).count() == 1
+    stored = db_session.get(DocumentModel, str(created.document.id))
+    assert stored is not None
+    assert stored.source_object_key in storage.objects
+    assert stored.file_data == b"cleanup-fail"
+    assert stored.result is not None
+    assert stored.result.markdown == created.result.markdown
+    assert stored.result.markdown_object_key is None
+
+
+def test_create_document_persists_fallback_when_commit_and_cleanup_fail(db_session) -> None:
+    class CommitFailOnceCleanupFailStorage:
+        def __init__(self) -> None:
+            self.objects: dict[str, bytes] = {}
+            self.delete_count = 0
+
+        def put_bytes(self, *, key: str, data: bytes, content_type: str) -> str:
+            del content_type
+            self.objects[key] = data
+            return key
+
+        def get_bytes(self, *, key: str) -> bytes:
+            return self.objects[key]
+
+        def delete_object(self, *, key: str) -> None:
+            self.delete_count += 1
+            if self.delete_count == 1:
+                raise RuntimeError("cleanup delete failed")
+            self.objects.pop(key, None)
+
+    class CommitFailingSession:
+        def __init__(self, wrapped_session) -> None:
+            self.wrapped_session = wrapped_session
+            self.fail_next_commit = True
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self.wrapped_session, name)
+
+        def commit(self) -> None:
+            if self.fail_next_commit:
+                self.fail_next_commit = False
+                raise RuntimeError("forced commit failure")
+            self.wrapped_session.commit()
+
+        def rollback(self) -> None:
+            self.wrapped_session.rollback()
+
+    storage = CommitFailOnceCleanupFailStorage()
+    owner_user_id = _create_user(db_session)
+    service = DocumentService(
+        session=cast(Any, CommitFailingSession(db_session)),
+        storage=storage,
+    )
+
+    created = service.create_document(
+        owner_user_id=owner_user_id,
+        filename="commit-cleanup-fail.pdf",
+        content_type="application/pdf",
+        file_data=b"commit-cleanup-fail",
+    )
+
+    assert created.document.filename == "commit-cleanup-fail.pdf"
+    persisted = DocumentService(session=db_session, storage=storage).get_document_result(
+        created.document.id,
+        owner_user_id=owner_user_id,
+    )
+    assert (
+        persisted.result.canonical_json["document"]["sourceFilename"] == "commit-cleanup-fail.pdf"
+    )
+
+
+def test_get_document_result_uses_inline_fallback_when_object_backed_field_disappears(
+    db_session,
+) -> None:
+    class MarkdownCleanupFailingStorage:
+        def __init__(self) -> None:
+            self.objects: dict[str, bytes] = {}
+            self.put_count = 0
+            self.delete_count = 0
+
+        def put_bytes(self, *, key: str, data: bytes, content_type: str) -> str:
+            del content_type
+            self.put_count += 1
+            if self.put_count == 3:
+                raise RuntimeError("failed to write canonical json")
+            self.objects[key] = data
+            return key
+
+        def get_bytes(self, *, key: str) -> bytes:
+            return self.objects[key]
+
+        def delete_object(self, *, key: str) -> None:
+            self.delete_count += 1
+            if self.delete_count == 2:
+                raise RuntimeError("cleanup delete failed")
+            self.objects.pop(key, None)
+
+    storage = MarkdownCleanupFailingStorage()
+    service = DocumentService(session=db_session, storage=storage)
+    owner_user_id = _create_user(db_session)
+
+    created = service.create_document(
+        owner_user_id=owner_user_id,
+        filename="inline-fallback.pdf",
+        content_type="application/pdf",
+        file_data=b"inline-fallback",
+    )
+    stored = db_session.get(DocumentModel, str(created.document.id))
+    assert stored is not None
+    assert stored.result is not None
+    assert stored.result.markdown_object_key is not None
+
+    storage.objects.pop(stored.result.markdown_object_key, None)
+
+    persisted = service.get_document_result(created.document.id, owner_user_id=owner_user_id)
+    assert persisted.result.markdown == created.result.markdown
 
 
 def test_delete_document_fails_when_storage_delete_fails(db_session) -> None:


### PR DESCRIPTION
## Summary
- create 실패 후 cleanup delete가 끝까지 되지 않아도 요청을 복구하도록 처리했습니다
- DB row 없이 orphaned storage object만 남는 상태 대신 fallback document를 저장하도록 바꿨습니다
- 복구 이후 object-backed payload가 사라져도 inline payload로 결과를 읽을 수 있게 했습니다

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/documents/test_service.py tests/documents/test_router.py tests/storage/test_backends.py tests/test_config.py tests/test_system.py
- 14 passed, 23 skipped