### PR TITLE
chore(api): remove debug upload route

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -675,27 +675,6 @@
         }
       }
     },
-    "/debug/upload": {
-      "get": {
-        "tags": [
-          "debug"
-        ],
-        "summary": "Debug Upload Page",
-        "operationId": "debug_upload_page_debug_upload_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/healthz": {
       "get": {
         "tags": [

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,3 @@
-from importlib import import_module
-
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -34,14 +32,6 @@ app.add_exception_handler(Exception, api_error_handler)
 app.add_exception_handler(RequestValidationError, request_validation_error_handler)
 app.include_router(auth_router)
 app.include_router(documents_router)
-
-try:
-    debug_module = import_module("src.debug.router")
-except ModuleNotFoundError:
-    debug_module = None
-
-if debug_module is not None:
-    app.include_router(debug_module.router)
 
 
 @app.get("/healthz", tags=["system"])


### PR DESCRIPTION
## Summary

Remove the temporary test UI from the API service surface.

- remove `src.debug` router loading from `src/main.py`
- remove `/debug/upload` from `docs/openapi.json`

## Why

- remove temporary test UI from the API service surface

## Verification

- `uv run ruff check src tests`
- `uv run pyright`
- `uv run pytest`