### PR TITLE
chore(deploy): add Railway worker image for document-ai runtime

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -10,7 +10,6 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         fontconfig \
         fonts-noto-cjk \
         fonts-noto-core \
@@ -25,13 +24,13 @@ COPY pyproject.toml uv.lock ./
 
 RUN uv sync --frozen --no-dev
 
-# document-ai runtime dependencies (CPU)
-RUN python -m pip install --upgrade pip \
-    && python -m pip install \
+# document-ai runtime dependencies (CPU) installed into the uv project environment
+RUN uv run python -m pip install --upgrade pip \
+    && uv run python -m pip install \
         --index-url https://download.pytorch.org/whl/cpu \
         "torch==2.6.0+cpu" \
         "torchvision==0.21.0+cpu" \
-    && python -m pip install "mineru[pipeline]==2.7.6" "pymupdf>=1.24.0" "pillow>=10.0.0"
+    && uv run python -m pip install "mineru[pipeline]==2.7.6" "pymupdf>=1.24.0" "pillow>=10.0.0"
 
 COPY src ./src
 COPY migrations ./migrations

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ REDIS_URL=redis://default:password@host:6379/0
 PARSE_JOB_QUEUE_NAME=document-agent-api:parse-jobs
 
 PARSER_BACKEND=document_ai
-DOCUMENT_AI_COMMAND=uv run python -m src.worker.document_ai_entrypoint {input_path} {output_dir} --language ko --page-adaptive
+DOCUMENT_AI_COMMAND="uv run python -m src.worker.document_ai_entrypoint {input_path} {output_dir} --language ko --page-adaptive"
 DOCUMENT_AI_TIMEOUT_SECONDS=300
 WORKER_TEMP_ROOT=/tmp/document-agent-api-worker
 ```


### PR DESCRIPTION
## Summary

Add Railway-ready worker runtime packaging so `PARSER_BACKEND=document_ai` can run in deployment.

- add `Dockerfile.worker` dedicated to worker execution
- include `vendor/document-ai` in worker image
- install required runtime deps (PyMuPDF, Pillow, MinerU CPU stack)
- update README with Railway API/Worker Dockerfile split and env configuration

## Why

The previous integration established command boundaries for `document-ai`, but deployment still lacked guaranteed runtime packaging for the parser stack in Railway worker containers.

This change closes that gap by making worker runtime requirements explicit and reproducible at image build time.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/worker/document_ai_entrypoint.py tests/worker/test_document_ai_entrypoint.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/worker/test_document_ai_entrypoint.py`

Closes #16